### PR TITLE
Fix add member functionality

### DIFF
--- a/fix_add_member_permissions.sql
+++ b/fix_add_member_permissions.sql
@@ -1,7 +1,10 @@
--- Fix add member functionality by updating RLS policy
--- Drop the restrictive policy that only allows self-joining
+-- Fix add member functionality by updating RLS policies
+-- Run this script in your Supabase SQL Editor
+
+-- Drop existing restrictive policies
 DROP POLICY IF EXISTS "Users can add themselves to groups" ON public.group_memberships;
 DROP POLICY IF EXISTS "Users can add themselves or admins can add members" ON public.group_memberships;
+DROP POLICY IF EXISTS "Users can remove themselves from groups" ON public.group_memberships;
 
 -- Create new policy that allows both self-joining and admin-managed additions
 CREATE POLICY "Users can add themselves or admins can add members" ON public.group_memberships FOR INSERT 
@@ -13,9 +16,7 @@ WITH CHECK (
   )
 );
 
--- Also add a policy to allow admins to manage (update/delete) memberships
-DROP POLICY IF EXISTS "Users can remove themselves from groups" ON public.group_memberships;
-
+-- Allow users to remove themselves or admins to remove members
 CREATE POLICY "Users can remove themselves or admins can remove members" ON public.group_memberships FOR DELETE 
 USING (
   user_id = auth.uid() OR 

--- a/src/components/AddMemberDialog.tsx
+++ b/src/components/AddMemberDialog.tsx
@@ -27,46 +27,27 @@ export const AddMemberDialog = ({ groupId, onMemberAdded }: AddMemberDialogProps
 
     setIsLoading(true);
     try {
-      // Find user by email first
-      const { data: targetUser, error: findError } = await supabase
-        .from('profiles')
-        .select('user_id, email, username')
-        .eq('email', email.trim())
-        .single();
-
-      if (findError || !targetUser) {
-        throw new Error('User not found with this email address');
-      }
-
-      // Check if user is already a member
-      const { data: existingMember } = await supabase
-        .from('group_memberships')
-        .select('id')
-        .eq('group_id', groupId)
-        .eq('user_id', targetUser.user_id)
-        .single();
-
-      if (existingMember) {
-        throw new Error('User is already a member of this group');
-      }
-
-      // Add user to group directly
-      const { error: addError } = await supabase
-        .from('group_memberships')
-        .insert({
+      // Use the manage-group Edge Function to add member
+      const { data, error } = await supabase.functions.invoke('manage-group', {
+        body: {
+          action: 'add-member',
           group_id: groupId,
-          user_id: targetUser.user_id,
-          role: 'member'
-        });
+          email: email.trim()
+        }
+      });
 
-      if (addError) {
-        console.error('Error adding member:', addError);
-        throw new Error('Failed to add member to group');
+      if (error) {
+        console.error('Error adding member:', error);
+        throw new Error(error.message || 'Failed to add member to group');
+      }
+
+      if (data?.error) {
+        throw new Error(data.error);
       }
 
       toast({
         title: "Success",
-        description: `${targetUser.username || targetUser.email} added to group successfully`,
+        description: `Member added to group successfully`,
       });
 
       setEmail("");
@@ -92,30 +73,22 @@ export const AddMemberDialog = ({ groupId, onMemberAdded }: AddMemberDialogProps
         throw new Error('Friend not found');
       }
 
-      // Check if friend is already a member
-      const { data: existingMember } = await supabase
-        .from('group_memberships')
-        .select('id')
-        .eq('group_id', groupId)
-        .eq('user_id', friend.friend_id)
-        .single();
+      // Use the manage-group Edge Function to add friend by their email
+      const { data, error } = await supabase.functions.invoke('manage-group', {
+        body: {
+          action: 'add-member',
+          group_id: groupId,
+          email: friend.profile?.email
+        }
+      });
 
-      if (existingMember) {
-        throw new Error('Friend is already a member of this group');
+      if (error) {
+        console.error('Error adding friend:', error);
+        throw new Error(error.message || 'Failed to add friend to group');
       }
 
-      // Add friend to group
-      const { error: addError } = await supabase
-        .from('group_memberships')
-        .insert({
-          group_id: groupId,
-          user_id: friend.friend_id,
-          role: 'member'
-        });
-
-      if (addError) {
-        console.error('Error adding friend:', addError);
-        throw new Error('Failed to add friend to group');
+      if (data?.error) {
+        throw new Error(data.error);
       }
 
       toast({

--- a/supabase/migrations/20250730185300_restore_rls_policies.sql
+++ b/supabase/migrations/20250730185300_restore_rls_policies.sql
@@ -34,8 +34,15 @@ USING (
   )
 );
 
-CREATE POLICY "Users can add themselves to groups" ON public.group_memberships FOR INSERT 
-WITH CHECK (user_id = auth.uid());
+-- Allow users to add themselves OR group admins to add others
+CREATE POLICY "Users can add themselves or admins can add members" ON public.group_memberships FOR INSERT 
+WITH CHECK (
+  user_id = auth.uid() OR 
+  group_id IN (
+    SELECT group_id FROM public.group_memberships 
+    WHERE user_id = auth.uid() AND role = 'admin'
+  )
+);
 
 CREATE POLICY "Users can update their own memberships" ON public.group_memberships FOR UPDATE 
 USING (user_id = auth.uid());

--- a/supabase/migrations/20250801000000_fix_add_member_permissions.sql
+++ b/supabase/migrations/20250801000000_fix_add_member_permissions.sql
@@ -1,0 +1,13 @@
+-- Fix add member functionality by updating RLS policy
+-- Drop the restrictive policy that only allows self-joining
+DROP POLICY IF EXISTS "Users can add themselves to groups" ON public.group_memberships;
+
+-- Create new policy that allows both self-joining and admin-managed additions
+CREATE POLICY "Users can add themselves or admins can add members" ON public.group_memberships FOR INSERT 
+WITH CHECK (
+  user_id = auth.uid() OR 
+  group_id IN (
+    SELECT group_id FROM public.group_memberships 
+    WHERE user_id = auth.uid() AND role = 'admin'
+  )
+);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable group admins to add members by updating RLS policies and routing frontend calls through the `manage-group` Edge Function.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous RLS policy on `group_memberships` only permitted users to add themselves, blocking attempts by group admins to add others. The frontend `AddMemberDialog` was also bypassing the intended `manage-group` Edge Function, which has the necessary logic and permissions, by attempting direct database inserts. This PR corrects both issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-946e0349-7471-404f-8947-1e6bf7dda874">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-946e0349-7471-404f-8947-1e6bf7dda874">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>